### PR TITLE
Increase perfomance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Additionally you may want install `ac-html-csswatcher` and `ac-html-bootstrap`.
 ## Possible improvements of company-mode
 
 ```lisp
+;; (setq company-minimum-prefix-length 0)            ; WARNING, probably you will get perfomance issue if min len is 0!
 (setq company-tooltip-limit 20)                      ; bigger popup window
 (setq company-tooltip-align-annotations 't)          ; align annotations to the right tooltip border
 (setq company-idle-delay .3)                         ; decrease delay before autocompletion popup shows

--- a/company-web-jade.el
+++ b/company-web-jade.el
@@ -104,51 +104,58 @@ or
     (interactive (company-begin-backend 'company-web-jade))
     (ignore-case t)
     (duplicates nil)
-    (prefix (and (derived-mode-p 'jade-mode)
-                 (or (company-grab company-web-jade-value-regexp 1)
-                     (company-grab company-web-jade-tag-regexp 1)
-                     (company-grab company-web-jade-id-regexp 2)
-                     (company-grab company-web-jade-class-regexp 2)
-                     (company-grab company-web-jade-attribute-regexp 1))))
+    (prefix (let ((bound (company-web-backward-min-tag-bound)))
+              (and (derived-mode-p 'jade-mode)
+                   (or (company-grab company-web-jade-value-regexp 1 bound)
+                       (company-grab company-web-jade-tag-regexp 1 bound)
+                       (company-grab company-web-jade-id-regexp 2 bound)
+                       (company-grab company-web-jade-class-regexp 2 bound)
+                       (company-grab company-web-jade-attribute-regexp 1 bound)))))
+
     (candidates
-     (cond
-      ;; value
-      ((company-grab company-web-jade-value-regexp 1)
-       (all-completions arg (company-web-candidates-attrib-values (company-web-jade-current-tag)
-                                                           (company-web-jade-current-attribute))))
-      ;; class ".foo" or id "#bar"
-      ((and (not (company-web-is-point-in-string-face))
-            (company-grab company-web-jade-id-regexp 1))
-       (let ((tag (company-grab company-web-jade-id-regexp 1)))
-         (if (string= "" tag)
-             (setq tag "div"))
-         (all-completions arg (company-web-candidates-attrib-values tag "id"))))
+     (let ((bound (company-web-backward-min-tag-bound)))
+       (cond
+        ;; value
+        ((company-grab company-web-jade-value-regexp 1 bound)
+         (all-completions arg (company-web-candidates-attrib-values (company-web-jade-current-tag)
+                                                                    (company-web-jade-current-attribute)
+                                                                    bound)))
+        ;; class ".foo" or id "#bar"
+        ((and (not (company-web-is-point-in-string-face))
+              (company-grab company-web-jade-id-regexp 1 bound))
+         (let ((tag (company-grab company-web-jade-id-regexp 1 bound)))
+           (if (string= "" tag)
+               (setq tag "div"))
+           (all-completions arg (company-web-candidates-attrib-values tag "id" bound))))
 
-      ((company-web-grab-not-in-string company-web-jade-class-regexp 1)
-       (let ((tag (company-grab company-web-jade-class-regexp 1)))
-         (if (string= "" tag)
-             (setq tag "div"))
-         (all-completions arg (company-web-candidates-attrib-values tag "class"))))
+        ((company-web-grab-not-in-string company-web-jade-class-regexp 1 bound)
+         (let ((tag (company-grab company-web-jade-class-regexp 1 bound)))
+           (if (string= "" tag)
+               (setq tag "div"))
+           (all-completions arg (company-web-candidates-attrib-values tag "class" bound))))
 
-      ;; tag
-      ((company-web-grab-not-in-string company-web-jade-tag-regexp 1)
-       (all-completions arg (company-web-candidates-tags)))
-      ;; attr
-      ((company-web-grab-not-in-string company-web-jade-attribute-regexp 1)
-       (all-completions arg (company-web-candidates-attribute (company-web-jade-current-tag))))))
+        ;; tag
+        ((company-web-grab-not-in-string company-web-jade-tag-regexp 1 bound)
+         (all-completions arg (company-web-candidates-tags)))
+        ;; attr
+        ((company-web-grab-not-in-string company-web-jade-attribute-regexp 1 bound)
+         (all-completions arg (company-web-candidates-attribute (company-web-jade-current-tag)))))))
+
     (annotation (company-web-annotation arg))
+
     (doc-buffer
-     (cond
-      ((or (company-web-grab-not-in-string company-web-jade-id-regexp 1)
-	   (company-web-grab-not-in-string company-web-jade-class-regexp 2)
-	   (company-grab company-web-jade-value-regexp 1))
-       (company-web-candidate-prop-doc arg))
-      ;; tag
-      ((company-grab company-web-jade-tag-regexp 1)
-       (company-web-tag-doc arg))
-      ;; attr
-      ((company-grab company-web-jade-attribute-regexp 1)
-       (company-web-attribute-doc (company-web-jade-current-tag) arg))))))
+     (let ((bound (company-web-backward-min-tag-bound)))
+       (cond
+        ((or (company-web-grab-not-in-string company-web-jade-id-regexp 1 bound)
+             (company-web-grab-not-in-string company-web-jade-class-regexp 2 bound)
+             (company-grab company-web-jade-value-regexp 1 bound))
+         (company-web-candidate-prop-doc arg))
+        ;; tag
+        ((company-grab company-web-jade-tag-regexp 1 bound)
+         (company-web-tag-doc arg))
+        ;; attr
+        ((company-grab company-web-jade-attribute-regexp 1 bound)
+         (company-web-attribute-doc (company-web-jade-current-tag) arg)))))))
 
 (provide 'company-web-jade)
 ;;; company-web-jade.el ends here

--- a/company-web-slim.el
+++ b/company-web-slim.el
@@ -108,49 +108,55 @@ or
     (interactive (company-begin-backend 'company-web-slim))
     (ignore-case t)
     (duplicates nil)
-    (prefix (and (derived-mode-p 'slim-mode)
-                 (or (company-grab company-web-slim-value-regexp 1)
-                     (company-grab company-web-slim-tag-regexp 1)
-                     (company-grab company-web-slim-id-regexp 2)
-                     (company-grab company-web-slim-class-regexp 2)
-                     (company-grab company-web-slim-attribute-regexp 1))))
-    (candidates
-     (cond
-      ;; value
-      ((company-grab company-web-slim-value-regexp 1)
-       (all-completions arg (company-web-candidates-attrib-values (company-web-slim-current-tag)
-                                                           (company-web-slim-current-attribute))))
-      ;; class ".foo" or id "#bar"
-      ((company-web-grab-not-in-string company-web-slim-id-regexp 1)
-      (let ((tag (company-grab company-web-slim-id-regexp 1)))
-         (if (string= "" tag)
-             (setq tag "div"))
-         (all-completions arg (company-web-candidates-attrib-values tag "id"))))
+    (prefix (let ((bound (company-web-backward-min-tag-bound)))
+              (and (derived-mode-p 'slim-mode)
+                 (or (company-grab company-web-slim-value-regexp 1 bound)
+                     (company-grab company-web-slim-tag-regexp 1 bound)
+                     (company-grab company-web-slim-id-regexp 2 bound)
+                     (company-grab company-web-slim-class-regexp 2 bound)
+                     (company-grab company-web-slim-attribute-regexp 1 bound)))))
 
-      ((company-web-grab-not-in-string company-web-slim-class-regexp 1)
-       (let ((tag (company-grab company-web-slim-class-regexp 1)))
-         (if (string= "" tag)
-             (setq tag "div"))
-         (all-completions arg (company-web-candidates-attrib-values tag "class"))))
-      ;; tag
-      ((company-web-grab-not-in-string company-web-slim-tag-regexp 1)
-       (all-completions arg (company-web-candidates-tags)))
-      ;; attr
-      ((company-web-grab-not-in-string company-web-slim-attribute-regexp 1)
-       (all-completions arg (company-web-candidates-attribute (company-web-slim-current-tag))))))
+    (candidates
+     (let ((bound (company-web-backward-min-tag-bound)))
+       (cond
+        ;; value
+        ((company-grab company-web-slim-value-regexp 1 bound)
+         (all-completions arg (company-web-candidates-attrib-values (company-web-slim-current-tag)
+                                                                    (company-web-slim-current-attribute)
+                                                                    bound)))
+        ;; class ".foo" or id "#bar"
+        ((company-web-grab-not-in-string company-web-slim-id-regexp 1 bound)
+         (let ((tag (company-grab company-web-slim-id-regexp 1 bound)))
+           (if (string= "" tag)
+               (setq tag "div"))
+           (all-completions arg (company-web-candidates-attrib-values tag "id" bound))))
+        ((company-web-grab-not-in-string company-web-slim-class-regexp 1 bound)
+         (let ((tag (company-grab company-web-slim-class-regexp 1 bound)))
+           (if (string= "" tag)
+               (setq tag "div"))
+           (all-completions arg (company-web-candidates-attrib-values tag "class" bound))))
+        ;; tag
+        ((company-web-grab-not-in-string company-web-slim-tag-regexp 1 bound)
+         (all-completions arg (company-web-candidates-tags)))
+        ;; attr
+        ((company-web-grab-not-in-string company-web-slim-attribute-regexp 1 bound)
+         (all-completions arg (company-web-candidates-attribute (company-web-slim-current-tag)))))))
+
     (annotation (company-web-annotation arg))
+
     (doc-buffer
-     (cond
-      ((or (company-web-grab-not-in-string company-web-slim-id-regexp 1)
-	   (company-web-grab-not-in-string company-web-slim-class-regexp 2)
-	   (company-grab company-web-slim-value-regexp 1))
-       (company-web-candidate-prop-doc arg))
-      ;; tag
-      ((company-grab company-web-slim-tag-regexp 1)
-       (company-web-tag-doc arg))
-      ;; attr
-      ((company-grab company-web-slim-attribute-regexp 1)
-       (company-web-attribute-doc (company-web-slim-current-tag) arg))))))
+     (let ((bound (company-web-backward-min-tag-bound)))
+       (cond
+        ((or (company-web-grab-not-in-string company-web-slim-id-regexp 1 bound)
+             (company-web-grab-not-in-string company-web-slim-class-regexp 2 bound)
+             (company-grab company-web-slim-value-regexp 1 bound))
+         (company-web-candidate-prop-doc arg))
+        ;; tag
+        ((company-grab company-web-slim-tag-regexp 1 bound)
+         (company-web-tag-doc arg))
+        ;; attr
+        ((company-grab company-web-slim-attribute-regexp 1 bound)
+         (company-web-attribute-doc (company-web-slim-current-tag) arg)))))))
 
 (provide 'company-web-slim)
 ;;; company-web-slim.el ends here

--- a/company-web-slim.el
+++ b/company-web-slim.el
@@ -110,11 +110,11 @@ or
     (duplicates nil)
     (prefix (let ((bound (company-web-backward-min-tag-bound)))
               (and (derived-mode-p 'slim-mode)
-                 (or (company-grab company-web-slim-value-regexp 1 bound)
-                     (company-grab company-web-slim-tag-regexp 1 bound)
-                     (company-grab company-web-slim-id-regexp 2 bound)
-                     (company-grab company-web-slim-class-regexp 2 bound)
-                     (company-grab company-web-slim-attribute-regexp 1 bound)))))
+                   (or (company-grab company-web-slim-value-regexp 1 bound)
+                       (company-grab company-web-slim-tag-regexp 1 bound)
+                       (company-grab company-web-slim-id-regexp 2 bound)
+                       (company-grab company-web-slim-class-regexp 2 bound)
+                       (company-grab company-web-slim-attribute-regexp 1 bound)))))
 
     (candidates
      (let ((bound (company-web-backward-min-tag-bound)))

--- a/company-web.el
+++ b/company-web.el
@@ -114,14 +114,9 @@
 
 (defun company-web-load-list-from-file (filepath)
   "Return a list separated by \\n from FILEPATH."
-  (with-current-buffer (find-file-noselect filepath)
-    (unwind-protect
-        (split-string (save-restriction
-                        (widen)
-                        (buffer-substring-no-properties
-                         (point-min) (point-max)))
-                      "\n" t)
-      (kill-buffer))))
+  (with-temp-buffer
+    (insert-file-contents filepath)
+    (split-string (buffer-string) "\n" t)))
 
 (defun company-web-is-point-in-string-face ()
   "t if text's face(s) at point is in `company-web-string-check-faces'."

--- a/company-web.el
+++ b/company-web.el
@@ -258,7 +258,7 @@ DOCUMENTATION is string or function."
 (defun company-web-doc-buffer (&optional string)
   (with-current-buffer (get-buffer-create "*html-documentation*")
     (set (make-local-variable 'font-lock-defaults)
-	 '(company-web-doc-font-lock-keywords))
+         '(company-web-doc-font-lock-keywords))
     (font-lock-mode t)
     (erase-buffer)
     (when string

--- a/company-web.el
+++ b/company-web.el
@@ -70,6 +70,14 @@
   :group 'company-web
   :type 'boolean)
 
+(defcustom company-web-backward-tag-limit 2048
+  "Bound for backward searching to determinate where html tag is started. Big value may decrease perfomance"
+  :group 'company-web :type 'integer)
+
+(defun company-web-backward-min-tag-bound ()
+  (max (- (point) company-web-backward-tag-limit)
+       (point-min)))
+
 (defface company-web-doc-base-face
   '((((class color) (background light))
      :foreground "navy" :inherit variable-pitch)
@@ -222,13 +230,13 @@ DOCUMENTATION is string or function."
                          (company-web-all-files-named (concat "html-attributes-complete/global-" attribute))))
     (-flatten items)))
 
-(defun company-web-candidates-attrib-values (tag attribute)
+(defun company-web-candidates-attrib-values (tag attribute bound)
   (if (and company-web-complete-css
            (string= attribute "style")
-           (save-excursion (re-search-backward "[\"']" nil t))
-           (save-excursion (re-search-backward "\\([[:alpha:]@_-]\\) *:[^;]*\\=" nil t)))
+           (save-excursion (re-search-backward "[\"']" bound t))
+           (save-excursion (re-search-backward "\\([[:alpha:]@_-]\\) *:[^;]*\\=" bound t)))
       (-flatten (company-web-make-candidate "CSS" (company-css-property-values
-                                                   (company-grab company-css-property-value-regexp 1))))
+                                                   (company-grab company-css-property-value-regexp 1 bound))))
     (company-web-candidates-attrib-values-internal tag attribute)))
 
 (defun company-web-annotation (candidate)
@@ -292,10 +300,10 @@ Property of doc CANDIDATE or load file from `html-attributes-short-docs/global-C
     (when doc
       (company-web-doc-buffer doc))))
 
-(defun company-web-grab-not-in-string (regexp expression)
+(defun company-web-grab-not-in-string (regexp expression bound)
   "Like `company-grab' but not in string"
   (and (not (company-web-is-point-in-string-face))
-       (company-grab regexp expression)))
+       (company-grab regexp expression bound)))
 
 (defconst company-web-selector "[[:alnum:]_-]"
   "Regexp of html attribute or tag")

--- a/features/candidates-html-emmet.feature
+++ b/features/candidates-html-emmet.feature
@@ -1,10 +1,9 @@
 Feature company-web-html and emmet integration
-  
     Background:
       Given I turn on html-mode
       And I turn on emmet-mode
 
-  Scenario: html tag candidates
+  Scenario: [emmet-mode] tag candidates
     Given the buffer is empty
     And I insert:
     """
@@ -14,7 +13,56 @@ Feature company-web-html and emmet integration
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates contains "template"
 
-  Scenario: No html emmet tag candidates in open tag
+  Scenario: [emmet-mode] attribute candidates
+    Given the buffer is empty
+    And I insert:
+    """
+    <foo bar>
+      html>head+body.container>.row>.col-lg-12>form.form-horizontal[method="POST"ac]
+    """
+    And I press "<left>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "action"
+    Then company-web-html candidates not contains "div"
+
+  # TODO: Improve tag detect regexp to allow whitespace between [ ]
+  # Scenario: emmet: two attributes
+  #   Given the buffer is empty
+  #   And I insert:
+  #   """
+  #   <foo bar>
+  #     form.form-inline[action="/api/foo" method=""
+  #   """
+  #   And I press "<left>"
+  #   And I execute company-web-html candidates command at current point
+  #   Then company-web-html candidates contains "POST"
+  #   Then company-web-html candidates not contains "action"
+  #   Then company-web-html candidates not contains "div"
+
+  Scenario: [emmet-mode] value candidates
+    Given the buffer is empty
+    And I insert:
+    """
+    <foo bar>
+      div[dir=""]
+    """
+    And I press "<left><left>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "ltr"
+    Then company-web-html candidates not contains "div"
+
+  Scenario: [emmet-mode] value candidates if only emmet in buffer
+    Given the buffer is empty
+    And I insert:
+    """
+      form[method=""
+    """
+    And I press "<backspace>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "POST"
+    Then company-web-html candidates not contains "action"
+
+  Scenario: [emmet-mode] No html emmet tag candidates in open tag
     Given the buffer is empty
     And I insert:
     """
@@ -24,5 +72,12 @@ Feature company-web-html and emmet integration
     And I execute company-web-html candidates command at current point
     Then company-web-html have no candidates
 
-# TODO:  need   emmet-preview  test,  I   don't  know  how   to  check
-# emmet-preview overlay for now :(
+    And I press "<backspace><backspace><backspace>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates not contains "template"
+    Then company-web-html candidates contains "tabindex"
+
+    # TODO:  need  emmet-preview test, I don't  know  how   to  check
+    # emmet-preview overlay for now :(
+
+    # TODO: Add doc test

--- a/features/candidates-html-emmet.feature
+++ b/features/candidates-html-emmet.feature
@@ -51,7 +51,7 @@ Feature company-web-html and emmet integration
     Then company-web-html candidates contains "ltr"
     Then company-web-html candidates not contains "div"
 
-  Scenario: [emmet-mode] value candidates if only emmet in buffer
+  Scenario: [emmet-mode] value candidates if only emmet in buffer and quote is open
     Given the buffer is empty
     And I insert:
     """

--- a/features/candidates-html.feature
+++ b/features/candidates-html.feature
@@ -30,7 +30,7 @@ Feature company-web-html candidate
     Then company-web-html candidates are "("class")"
     And company-web-html candidates not contains "div"
 
-  Scenario: [html-mode] second attribute's candidates
+  Scenario: [html-mode] second attribute candidate
     Given the buffer is empty
     And I insert:
     """

--- a/features/candidates-html.feature
+++ b/features/candidates-html.feature
@@ -2,13 +2,14 @@ Feature company-web-html candidate
   Background:
     Given I turn on html-mode
 
-  Scenario: html tag candidates
+  Scenario: [html-mode] tag candidates
     Given the buffer is empty
     And I insert:
     """
     <t
     """
     And I execute company-web-html candidates command at current point
+    And company-web-html-current-tag return "nil"
     Then company-web-html candidates contains "template"
     And company-web-html candidates contains "table"
     And company-web-html candidates not contains "class"
@@ -17,27 +18,42 @@ Feature company-web-html candidate
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates are "("template")"
  
-  Scenario: html attribute candidates
+  Scenario: [html-mode] attribute candidates
     Given the buffer is empty
     And I insert:
     """
     <div cla
     """
+    And company-web-html-current-tag return ""div""
+    And company-web-html-current-attribute return "nil"
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates are "("class")"
     And company-web-html candidates not contains "div"
 
-  Scenario: html attribute value candidates
+  Scenario: [html-mode] second attribute's candidates
+    Given the buffer is empty
+    And I insert:
+    """
+    <div tabindex cla
+    """
+    And company-web-html-current-tag return ""div""
+    And company-web-html-current-attribute return "nil"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates are "("class")"
+    And company-web-html candidates not contains "div"
+
+  Scenario: [html-mode] attribute value candidates
     Given the buffer is empty
     And I insert:
     """
     <div dir=""
     """
     And I press "<left>"
+    And company-web-html-current-attribute return ""dir""
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates contains "auto"
 
-  Scenario: html attribute style candidates
+  Scenario: [html-mode] attribute style candidates
     Given the buffer is empty
     And I insert:
     """
@@ -49,18 +65,33 @@ Feature company-web-html candidate
     And company-web-html candidates contains "font"
     And company-web-html candidates not contains "div"
 
-  Scenario: html attribute style candidates usign "'" quote
+  Scenario: [html-mode] attribute style candidates usign "'" quote
     Given the buffer is empty
     And I insert:
     """
     <div style='
     """
     And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "background"
     Then company-web-html candidates contains "animation"
     And company-web-html candidates contains "font"
     And company-web-html candidates not contains "div"
 
-  Scenario: html attribute style candidates usign "'" quote and more attributes
+  Scenario: [html-mode] Able to complete even if parent element has ":" char
+    Given the buffer is empty
+    And I insert:
+    """
+    <span foo="http://abc.com">
+      <text class="" style=""
+    """
+    And I press "<left>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "background"
+    Then company-web-html candidates contains "animation"
+    And company-web-html candidates contains "font"
+    And company-web-html candidates not contains "div"
+
+  Scenario: [html-mode] attribute style candidates usign "'" quote and more attributes
     Given the buffer is empty
     And I insert:
     """
@@ -69,19 +100,105 @@ Feature company-web-html candidate
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates contains "style"
 
-  Scenario: html attribute CSS candidates
+  Scenario: [html-mode] Complete CSS candidates
     Given the buffer is empty
     And I insert:
     """
-      <div style="font-family:  "
+      <div class="xyz" style="font-family:  "
     """
     And I press "<left><left>"
+    And company-web-html-current-tag return ""div""
+    And company-web-html-current-attribute return ""style""
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates contains "Courier"
     And company-web-html candidates not contains "div"
     And company-web-html candidates not contains "color"
     And company-web-html candidates not contains "red"
 
+    And I insert " "
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "Courier"
+    And company-web-html candidates not contains "div"
     And I insert ";"
     And I execute company-web-html candidates command at current point
     Then company-web-jade candidates contains "color"
+    And I insert "color:"
+    And I execute company-web-html candidates command at current point
+    And company-web-html candidates contains "red"
+    And company-web-html candidates not contains "div"
+
+  Scenario: [html-mode] attribute CSS candidates when quote is not closed
+    Given the buffer is empty
+    And I insert:
+    """
+      <div style=""
+    """
+    And I press "<backspace>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "background"
+    And company-web-html candidates not contains "div"
+    And I insert "background:"
+    And I execute company-web-html candidates command at current point
+    Then company-web-jade candidates contains "red"
+    And company-web-html candidates not contains "div"
+    And I insert ";font:"
+    And I execute company-web-html candidates command at current point
+    Then company-web-jade candidates contains "cursive"
+    And company-web-html candidates not contains "red"
+
+  Scenario: [html-mode] attribute CSS candidates when quote is closed
+    Given the buffer is empty
+    And I insert:
+    """
+      <div style=""
+    """
+    And I press "<left>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "background"
+    And company-web-html candidates not contains "div"
+    And I insert "background:"
+    And I execute company-web-html candidates command at current point
+    Then company-web-jade candidates contains "red"
+    And company-web-html candidates not contains "div"
+    And I insert ";font:"
+    And I execute company-web-html candidates command at current point
+    Then company-web-jade candidates contains "cursive"
+    And company-web-html candidates not contains "red"
+
+  Scenario: [html-mode] attribute CSS candidates for last tag
+    Given the buffer is empty
+    And I insert:
+    """
+      <
+        input
+      />
+        <
+         div class="xyz" t
+    """
+    And company-web-html-current-tag return ""div""
+    And company-web-html-current-attribute return ""class""
+    And I execute company-web-html candidates command at current point
+    # no input specified candidates
+    And company-web-html candidates not contains "type"
+    Then company-web-html candidates contains "tabindex"
+
+  Scenario: [html-mode] bug 1: when tag length is 1 and space is 1
+    Given the buffer is empty
+    And I insert:
+    """
+      <link href="" rel="stylesheet" hreflang=""/>
+      <!DOCTYPE html>
+      <html><head>
+          <link href="" rel="stylesheet" hreflang="d"/>
+          <div style="background: whi" >
+              <template class="xx">
+                  <a dir=""
+    """
+    And I press "<left>"
+    And company-web-html-current-tag return ""a""
+    And company-web-html-current-attribute return ""dir""
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "ltr"
+    And company-web-html candidates not contains "div"
+
+    # TODO: Add doc test

--- a/features/candidates-jade.feature
+++ b/features/candidates-jade.feature
@@ -3,7 +3,7 @@ Feature company-web-jade candidate
   Background:
     Given I turn on jade-mode
 
-  Scenario: jade tag candidates
+  Scenario: [jade-mode] tag candidates
     Given the buffer is empty
     And I insert:
     """
@@ -18,7 +18,7 @@ Feature company-web-jade candidate
     And I execute company-web-jade candidates command at current point
     Then company-web-jade candidates are "("template")"
  
-  Scenario: jade attribute candidates
+  Scenario: [jade-mode] attribute candidates
     Given the buffer is empty
     And I insert:
     """
@@ -28,7 +28,7 @@ Feature company-web-jade candidate
     Then company-web-jade candidates are "("class")"
     And company-web-jade candidates not contains "div"
 
-  Scenario: jade attribute value candidates
+  Scenario: [jade-mode] attribute value candidates
     Given the buffer is empty
     And I insert:
     """
@@ -38,7 +38,7 @@ Feature company-web-jade candidate
     And I execute company-web-jade candidates command at current point
     Then company-web-jade candidates contains "auto"
 
-  Scenario: jade attribute value candidates quoted by "'"
+  Scenario: [jade-mode] attribute value candidates quoted by "'"
     Given the buffer is empty
     And I insert:
     """
@@ -50,7 +50,7 @@ Feature company-web-jade candidate
     And I execute company-web-jade candidates command at current point
     Then company-web-jade candidates contains "class"
 
-  Scenario: jade attribute style candidates
+  Scenario: [jade-mode] attribute style candidates
     Given the buffer is empty
     And I insert:
     """
@@ -62,7 +62,7 @@ Feature company-web-jade candidate
     And company-web-jade candidates contains "font"
     And company-web-jade candidates not contains "div"
 
-  Scenario: jade attribute CSS candidates
+  Scenario: [jade-mode] attribute CSS candidates
     Given the buffer is empty
     And I insert:
     """

--- a/features/candidates-slim.feature
+++ b/features/candidates-slim.feature
@@ -3,7 +3,7 @@ Feature company-web-slim candidate
   Background:
     Given I turn on slim-mode
 
-  Scenario: slim tag candidates
+  Scenario: [slim-mode] tag candidates
     Given the buffer is empty
     And I insert:
     """
@@ -18,7 +18,7 @@ Feature company-web-slim candidate
     And I execute company-web-slim candidates command at current point
     Then company-web-slim candidates are "("template")"
  
-  Scenario: slim attribute candidates
+  Scenario: [slim-mode] attribute candidates
     Given the buffer is empty
     And I insert:
     """
@@ -28,7 +28,7 @@ Feature company-web-slim candidate
     Then company-web-slim candidates are "("class")"
     And company-web-slim candidates not contains "div"
 
-  Scenario: slim attribute value candidates
+  Scenario: [slim-mode] attribute value candidates
     Given the buffer is empty
     And I insert:
     """
@@ -38,7 +38,7 @@ Feature company-web-slim candidate
     And I execute company-web-slim candidates command at current point
     Then company-web-slim candidates contains "auto"
 
-  Scenario: slim attribute style candidates
+  Scenario: [slim-mode] attribute style candidates
     Given the buffer is empty
     And I insert:
     """
@@ -50,7 +50,7 @@ Feature company-web-slim candidate
     And company-web-slim candidates contains "font"
     And company-web-slim candidates not contains "div"
 
-  Scenario: slim multiple attributes
+  Scenario: [slim-mode] multiple attributes
     Given the buffer is empty
     And I insert:
     """
@@ -61,7 +61,7 @@ Feature company-web-slim candidate
     And company-web-slim candidates not contains "color"
     And company-web-slim candidates not contains "canvas"
 
-  Scenario: slim attribute CSS candidates
+  Scenario: [slim-mode] attribute CSS candidates
     Given the buffer is empty
     And I insert:
     """
@@ -77,4 +77,4 @@ Feature company-web-slim candidate
     And I insert "; "
     And I execute company-web-slim candidates command at current point
     Then company-web-slim candidates contains "color"
-"
+

--- a/features/candidates-web.feature
+++ b/features/candidates-web.feature
@@ -30,7 +30,7 @@ Feature company-web-html candidate Background:
     Then company-web-html candidates are "("class")"
     And company-web-html candidates not contains "div"
 
-  Scenario: [web-mode] second attribute's candidates
+  Scenario: [web-mode] second attribute candidate
     Given the buffer is empty
     And I insert:
     """

--- a/features/candidates-web.feature
+++ b/features/candidates-web.feature
@@ -1,14 +1,15 @@
-Feature company-web-html candidate
+Feature company-web-html candidate Background:
   Background:
     Given I turn on web-mode
 
-  Scenario: web-mode tag candidates
+  Scenario: [web-mode] tag candidates
     Given the buffer is empty
     And I insert:
     """
     <t
     """
     And I execute company-web-html candidates command at current point
+    And company-web-html-current-tag return "nil"
     Then company-web-html candidates contains "template"
     And company-web-html candidates contains "table"
     And company-web-html candidates not contains "class"
@@ -17,27 +18,42 @@ Feature company-web-html candidate
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates are "("template")"
  
-  Scenario: web-mode attribute candidates
+  Scenario: [web-mode] attribute candidates
     Given the buffer is empty
     And I insert:
     """
     <div cla
     """
+    And company-web-html-current-tag return ""div""
+    And company-web-html-current-attribute return "nil"
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates are "("class")"
     And company-web-html candidates not contains "div"
 
-  Scenario: web-mode attribute value candidates
+  Scenario: [web-mode] second attribute's candidates
+    Given the buffer is empty
+    And I insert:
+    """
+    <div tabindex cla
+    """
+    And company-web-html-current-tag return ""div""
+    And company-web-html-current-attribute return "nil"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates are "("class")"
+    And company-web-html candidates not contains "div"
+
+  Scenario: [web-mode] attribute value candidates
     Given the buffer is empty
     And I insert:
     """
     <div dir=""
     """
     And I press "<left>"
+    And company-web-html-current-attribute return ""dir""
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates contains "auto"
 
-  Scenario: web-mode attribute style candidates
+  Scenario: [web-mode] attribute style candidates
     Given the buffer is empty
     And I insert:
     """
@@ -49,18 +65,33 @@ Feature company-web-html candidate
     And company-web-html candidates contains "font"
     And company-web-html candidates not contains "div"
 
-  Scenario: web-mode attribute style candidates usign "'" quote
+  Scenario: [web-mode] attribute style candidates usign "'" quote
     Given the buffer is empty
     And I insert:
     """
     <div style='
     """
     And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "background"
     Then company-web-html candidates contains "animation"
     And company-web-html candidates contains "font"
     And company-web-html candidates not contains "div"
 
-  Scenario: web-mode attribute style candidates usign "'" quote and more attributes
+  Scenario: [web-mode] Able to complete even if parent element has ":" char
+    Given the buffer is empty
+    And I insert:
+    """
+    <span foo="http://abc.com">
+      <text class="" style=""
+    """
+    And I press "<left>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "background"
+    Then company-web-html candidates contains "animation"
+    And company-web-html candidates contains "font"
+    And company-web-html candidates not contains "div"
+
+  Scenario: [web-mode] attribute style candidates usign "'" quote and more attributes
     Given the buffer is empty
     And I insert:
     """
@@ -69,19 +100,103 @@ Feature company-web-html candidate
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates contains "style"
 
-  Scenario: web-mode attribute CSS candidates
+  Scenario: [web-mode] Complete CSS candidates
     Given the buffer is empty
     And I insert:
     """
-      <div style="font-family:  "
+      <div class="xyz" style="font-family:  "
     """
     And I press "<left><left>"
+    And company-web-html-current-tag return ""div""
+    And company-web-html-current-attribute return ""style""
     And I execute company-web-html candidates command at current point
     Then company-web-html candidates contains "Courier"
     And company-web-html candidates not contains "div"
     And company-web-html candidates not contains "color"
     And company-web-html candidates not contains "red"
 
+    And I insert " "
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "Courier"
+    And company-web-html candidates not contains "div"
     And I insert ";"
     And I execute company-web-html candidates command at current point
     Then company-web-jade candidates contains "color"
+    And I insert "color:"
+    And I execute company-web-html candidates command at current point
+    And company-web-html candidates contains "red"
+    And company-web-html candidates not contains "div"
+
+  Scenario: [web-mode] attribute CSS candidates when quote is not closed
+    Given the buffer is empty
+    And I insert:
+    """
+      <div style=""
+    """
+    And I press "<backspace>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "background"
+    And company-web-html candidates not contains "div"
+    And I insert "background:"
+    And I execute company-web-html candidates command at current point
+    Then company-web-jade candidates contains "red"
+    And company-web-html candidates not contains "div"
+    And I insert ";font:"
+    And I execute company-web-html candidates command at current point
+    Then company-web-jade candidates contains "cursive"
+    And company-web-html candidates not contains "red"
+
+  Scenario: [web-mode] attribute CSS candidates when quote is closed
+    Given the buffer is empty
+    And I insert:
+    """
+      <div style=""
+    """
+    And I press "<left>"
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "background"
+    And company-web-html candidates not contains "div"
+    And I insert "background:"
+    And I execute company-web-html candidates command at current point
+    Then company-web-jade candidates contains "red"
+    And company-web-html candidates not contains "div"
+    And I insert ";font:"
+    And I execute company-web-html candidates command at current point
+    Then company-web-jade candidates contains "cursive"
+    And company-web-html candidates not contains "red"
+
+  Scenario: [web-mode] attribute CSS candidates for last tag
+    Given the buffer is empty
+    And I insert:
+    """
+      <
+        input
+      />
+        <
+         div class="xyz" t
+    """
+    And company-web-html-current-tag return ""div""
+    And company-web-html-current-attribute return ""class""
+    And I execute company-web-html candidates command at current point
+    # no input specified candidates
+    And company-web-html candidates not contains "type"
+    Then company-web-html candidates contains "tabindex"
+
+  Scenario: [web-mode] bug 1: when tag length is 1 and space is 1
+    Given the buffer is empty
+    And I insert:
+    """
+      <link href="" rel="stylesheet" hreflang=""/>
+      <!DOCTYPE html>
+      <html><head>
+          <link href="" rel="stylesheet" hreflang="d"/>
+          <div style="background: whi" >
+              <template class="xx">
+                  <a dir=""
+    """
+    And I press "<left>"
+    And company-web-html-current-tag return ""a""
+    And company-web-html-current-attribute return ""dir""
+    And I execute company-web-html candidates command at current point
+    Then company-web-html candidates contains "ltr"
+    And company-web-html candidates not contains "div"

--- a/features/step-definitions/company-web-html-steps.el
+++ b/features/step-definitions/company-web-html-steps.el
@@ -39,3 +39,14 @@
 (Then "^company-web-html candidates not contains\\(?: \"\\(.*\\)\"\\|:\\)$"
       (lambda (expected)
         (should (not (member expected company-web-test-candidates-output)))))
+
+(Then "^company-web-html-current-attribute return\\(?: \"\\(.*\\)\"\\|:\\)$"
+      (lambda (expected)
+        (let* ((tag-info (company-web-html-current-tag))
+               (tag-bound (cdr tag-info))
+               (attribute (company-web-html-current-attribute tag-bound)))
+          (should (equal attribute (read expected))))))
+
+(Then "^company-web-html-current-tag return\\(?: \"\\(.*\\)\"\\|:\\)$"
+      (lambda (expected)
+        (should (equal (car (company-web-html-current-tag)) (read expected)))))


### PR DESCRIPTION
- Improve Mem+cpu perfomance by removing `find-file-noselect`. `find-file-noselect` are slower due it init hooks, etc. Used with-temp-buffer + insert-file-contents
- web, html: improve regexp.
- web, html: Add bound limit for regexp backward search - limit is html tag begin
- web, html: more specs
